### PR TITLE
Access grand_total as computed property

### DIFF
--- a/components/PaymentPaypal.vue
+++ b/components/PaymentPaypal.vue
@@ -8,7 +8,7 @@
       <p>
         You are to pay for this order via PayPal.
       </p>
-      <paypal-button :grand-total="platformTotals['grand_total']"/>
+      <paypal-button :grand-total="grandTotal"/>
     </div>
   </div>
 
@@ -19,11 +19,9 @@ import PaypalButton from '../components/Button'
 
 export default {
   name: 'PaymentPaypal',
-  props: {
-    platformTotals: {
-      type: Object,
-      required: true,
-      default: () => {}
+  computed: {
+    grandTotal () {
+      return this.$store.state.cart.platformTotals['grand_total'] || 0
     }
   },
   components: {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ export default function (app, router, store, config) {
       // Dynamically inject a component into the order review section (optional)
       const Component = Vue.extend(PaypalComponent)
       const componentInstance = (new Component({
-        propsData: { platformTotals: app.$store.state.cart.platformTotals },
         parent: app
       }))
       componentInstance.$mount('#checkout-order-review-additional')


### PR DESCRIPTION
When hitting the checkout process before the vuex cart/UPD_TOTALS mutation has been called (e.g. seconds after adding the first product) the following error appears:

![bildschirmfoto 2018-08-09 um 16 49 12](https://user-images.githubusercontent.com/5840071/43907732-74e1ac08-9bf6-11e8-83e8-5b36c38c15ee.png)

I suggest to refer to grandTotal directly by using a computed property. I was not sure how to handle the fallback value which is 0 now. Probably this will require additional validation depending on the checkout process but it shouldn't either be possible to access it with no products in cart...