### PR TITLE
Render the paypal button instead standard order review.

### DIFF
--- a/components/Button.vue
+++ b/components/Button.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="paypal-button"><span v-show="loader" class="loader lds-dual-ring"/></div>
+  <div class="paypal-button"><span v-show="loader"/></div>
 </template>
 
 <script>
@@ -7,13 +7,6 @@ import { currentStoreView, adjustMultistoreApiUrl } from '@vue-storefront/store/
 
 export default {
   name: 'PaypalButton',
-  props: {
-    grandTotal: {
-      type: Number,
-      required: true,
-      default: 0
-    }
-  },
   data () {
     const storeView = currentStoreView()
     return {
@@ -28,6 +21,11 @@ export default {
       ? this.loadDependencies(this.configurePaypal)
       : this.configurePaypal()
   },
+  computed: {
+    grandTotal () {
+      return this.$store.state.cart.platformTotals['grand_total'] || 0
+    }
+  },
   methods: {
     loadDependencies (callback) {
       let jsUrl = 'https://www.paypalobjects.com/api/checkout.js'
@@ -41,7 +39,6 @@ export default {
       docHead.appendChild(docScript)
     },
     configurePaypal () {
-      this.loader = true
       window.paypal.Button.render({
         // Pass in env
         env: this.$config.paypal.env,
@@ -58,8 +55,6 @@ export default {
         // Pass a function to be called when the customer cancels the payment
         onCancel: this.onCancel
       }, this.$el)
-
-      setTimeout(function () { this.loader = false }.bind(this), 5000)
     },
     getTransactions () {
       return [{ amount: { total: this.grandTotal, currency: this.currency } }]
@@ -122,37 +117,5 @@ export default {
 </script>
 
 <style scoped>
-  .paypal-button {
-    position: relative;
-  }
-  .loader {
-    position: absolute;
-    top: -12px;
-    left: 40px;
-    z-index: 200;
-  }
-  .lds-dual-ring {
-    display: inline-block;
-    width: 64px;
-    height: 64px;
-  }
-  .lds-dual-ring:after {
-    content: " ";
-    display: block;
-    width: 46px;
-    height: 46px;
-    margin: 1px;
-    border-radius: 50%;
-    border: 5px solid #009cde;
-    border-color: #009cde transparent #009cde transparent;
-    animation: lds-dual-ring 1.2s linear infinite;
-  }
-  @keyframes lds-dual-ring {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
+
 </style>

--- a/components/PaymentPaypal.vue
+++ b/components/PaymentPaypal.vue
@@ -8,24 +8,7 @@
       <p>
         You are to pay for this order via PayPal.
       </p>
-      <paypal-button :grand-total="grandTotal"/>
     </div>
   </div>
 
 </template>
-
-<script>
-import PaypalButton from '../components/Button'
-
-export default {
-  name: 'PaymentPaypal',
-  computed: {
-    grandTotal () {
-      return this.$store.state.cart.platformTotals['grand_total'] || 0
-    }
-  },
-  components: {
-    PaypalButton
-  }
-}
-</script>

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import EventBus from 'core/plugins/event-bus'
 import extensionStore from './store'
 import extensionRoutes from './router'
 import PaypalComponent from './components/PaymentPaypal'
+import PaypalButton from './components/Button'
 
 const EXTENSION_KEY = 'vsf-payment-paypal'
 
@@ -35,10 +36,12 @@ export default function (app, router, store, config) {
 
       // Dynamically inject a component into the order review section (optional)
       const Component = Vue.extend(PaypalComponent)
-      const componentInstance = (new Component({
-        parent: app
-      }))
+      const componentInstance = (new Component({ parent: app }))
       componentInstance.$mount('#checkout-order-review-additional')
+
+      const Button = Vue.extend(PaypalButton)
+      const btnInstance = (new Button({ parent: app }))
+      btnInstance.$mount('#order-review-container')
     } else {
       // unregister the extensions placeorder handler
       EventBus.$off('checkout-before-placeOrder', placeOrder)

--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ export default function (app, router, store, config) {
       // Register the handler for what happens when they click the place order button.
       EventBus.$on('checkout-before-placeOrder', placeOrder)
 
+      EventBus.$emit('place-order-button-visible', false)
+
       // Dynamically inject a component into the order review section (optional)
       const Component = Vue.extend(PaypalComponent)
       const componentInstance = (new Component({ parent: app }))
@@ -41,8 +43,19 @@ export default function (app, router, store, config) {
 
       const Button = Vue.extend(PaypalButton)
       const btnInstance = (new Button({ parent: app }))
-      btnInstance.$mount('#order-review-container')
+
+      var container = document.querySelector('#place-order-container')
+      if (container !== null) {
+        container.appendChild(document.createElement('div')).id = 'place-order-container-child'
+      }
+
+      btnInstance.$mount('#place-order-container-child')
     } else {
+      EventBus.$emit('place-order-button-visible', true)
+
+      var el = document.querySelector('.paypal-button')
+      el !== null && el.parentNode.removeChild(el)
+
       // unregister the extensions placeorder handler
       EventBus.$off('checkout-before-placeOrder', placeOrder)
     }


### PR DESCRIPTION
@collymore need add the id with `order-review-container` to this line https://github.com/DivanteLtd/vue-storefront/blob/2cf12749378aebb171d2765b5af0054b8381cba5/src/themes/default/components/core/blocks/Checkout/OrderReview.vue#L65