### PR TITLE
Add support for UNRELEASED 1.8.0 version

### DIFF
--- a/store/actions.ts
+++ b/store/actions.ts
@@ -2,7 +2,7 @@ import { PaypalState } from '../types/PaypalState'
 import { ActionTree } from 'vuex';
 import * as types from './mutation-types'
 import config from 'config'
-import { adjustMultistoreApiUrl } from '@vue-storefront/store/lib/multistore'
+import { adjustMultistoreApiUrl } from '@vue-storefront/core/lib/multistore'
 
 // it's a good practice for all actions to return Promises with effect of their execution
 export const actions: ActionTree<PaypalState, any> = {


### PR DESCRIPTION
## [1.8.0] - UNRELEASED
### Changed / Improved
- `store/lib/multistore` has been moved to `core/lib/multistore` (#2224)

@collymore need merge it after release VSF 1.8.0
And need bump new tag for `vsf-payment-paypal` 