### PR TITLE
Pass telephone number parameter to PayPal

### DIFF
--- a/API/paypal/index.js
+++ b/API/paypal/index.js
@@ -94,6 +94,7 @@ function setPaypalNVPQuery(pay) {
     'PAYMENTREQUEST_0_SHIPTOSTREET2': pay.purchase_units[0].shipping.address.address_line_2,
     'PAYMENTREQUEST_0_SHIPTOCITY': pay.purchase_units[0].shipping.address.admin_area_2,
     'PAYMENTREQUEST_0_SHIPTOSTATE': pay.purchase_units[0].shipping.address.admin_area_1,
+    'PAYMENTREQUEST_0_SHIPTOPHONENUM': pay.purchase_units[0].phone,
     'PAYMENTREQUEST_0_SHIPTOZIP': pay.purchase_units[0].shipping.address.postal_code,
     'PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE': pay.purchase_units[0].shipping.address.country_code
   };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 06.11.2020
+
+- Pass telephone number parameter to PayPal
+
 ## [1.1.4] - 29.10.2020
 
 - Added error log informations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@develodesign/vsf-payment-paypal",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "The PayPal module built for vue-storefront, by Develo Design.",
   "main": "index.ts",
   "scripts": {

--- a/store/getters.ts
+++ b/store/getters.ts
@@ -37,7 +37,8 @@ export const getters: GetterTree<PaypalState, any> = {
         description: i18n.t('Need to return an item? We accept returns for unused items in packaging 60 days after you order'),
         items: getters.getProducts,
         amount: getters.getAmount,
-        shipping: getters.getShippingAddress
+        shipping: getters.getShippingAddress,
+        phone: getters.getShippingDetails.phoneNumber
       }]
     },
 


### PR DESCRIPTION
With this commit, when you pay with the "Pay with card option", the phone information is added to the PayPal pop-up.

![immagine](https://user-images.githubusercontent.com/3996291/98366973-1dc90180-2035-11eb-9409-7e3ed7436f1f.png)


