### PR TITLE
Add possibility to enable/disable payment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ $ git clone git@github.com:develodesign/vsf-payment-paypal.git ./vue-storefront/
 ```json
 "paypal": {
   "clientId": "",
+  "disabledMethods": ["giropay", "sofort", "card", "credit", "mybank", "sepa"], 
   "addJsToGlobalHead": true,
   "endpoint": {
     "complete": "/api/ext/paypal/complete",

--- a/hooks/beforeRegistration.ts
+++ b/hooks/beforeRegistration.ts
@@ -8,7 +8,8 @@ export function beforeRegistration(config, store) {
     const storeView = currentStoreView()
     const { currencyCode } = storeView.i18n
     const clientId = config.paypal.hasOwnProperty('clientId') ? config.paypal.clientId : ''
-    const sdkUrl = `https://www.paypal.com/sdk/js?client-id=${clientId}&currency=${currencyCode}&disable-funding=card,credit,mybank,sofort`
+    const disabledPaymentOptions = config.paypal.disabledMethods ? config.paypal.disabledMethods.join(',') : 'card,credit,mybank,sofort'
+    const sdkUrl = `https://www.paypal.com/sdk/js?client-id=${clientId}&currency=${currencyCode}&disable-funding=${disabledPaymentOptions}`
     var script = document.createElement('script')
     script.setAttribute('src', sdkUrl)
     document.head.appendChild(script)


### PR DESCRIPTION
for issue #161

Do prevent crashes of existing production build after an update, a default value with the previous options is provided. It will be used if the config entry has not been placed.